### PR TITLE
Correct syntax error

### DIFF
--- a/gophish/api/pages.py
+++ b/gophish/api/pages.py
@@ -8,7 +8,7 @@ class API(APIEndpoint):
     def get(self, page_id=None):
         """ Gets one or more pages """
         
-        return self.super(API, self).get(resource_id=page_id)
+        return super(API, self).get(resource_id=page_id)
 
     def post(self, page):
         """ Creates a new page """


### PR DESCRIPTION
Previous error:
>>> api.pages.get()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "build/bdist.linux-x86_64/egg/gophish/api/pages.py", line 11, in get
AttributeError: 'API' object has no attribute 'super'