### PR TITLE
Fixed AttributeErrors due to small errors

### DIFF
--- a/gophish/models.py
+++ b/gophish/models.py
@@ -20,7 +20,7 @@ class Model(object):
             if isinstance(val, datetime):
                 val = val.isoformat()
             # Parse custom classes
-            elif val and not isinstance(val, (str, list, dict)):
+            elif val and not isinstance(val, (int, float, str, list, dict)):
                 val = val.as_dict()
             # Parse lists of objects
             elif isinstance(val, list):
@@ -91,7 +91,7 @@ class Result(Model):
         return result
 
 
-class TimelineEntry(object):
+class TimelineEntry(Model):
     _valid_properties = {'email': None, 'time': None, 'message': None, 'details': None}
 
     @classmethod


### PR DESCRIPTION
I had the following error messages when attempting to save a list of campaigns to a json file.

```
AttributeError: 'TimelineEntry' object has no attribute 'as_dict'
AttributeError: 'float' object has no attribute 'as_dict'
AttributeError: 'int' object has no attribute 'as_dict'
```