### PR TITLE
Fixed issue #17

### DIFF
--- a/gophish/api/campaigns.py
+++ b/gophish/api/campaigns.py
@@ -4,7 +4,7 @@ from gophish.api import APIEndpoint
 
 
 class API(APIEndpoint):
-    def __init__(self, api, endpoint='/api/campaigns/'):
+    def __init__(self, api, endpoint='api/campaigns/'):
         """ Creates a new instance of the campaigns API """
 
         super(API, self).__init__(api, endpoint=endpoint, cls=Campaign)

--- a/gophish/api/groups.py
+++ b/gophish/api/groups.py
@@ -3,7 +3,7 @@ from gophish.api import APIEndpoint
 
 
 class API(APIEndpoint):
-    def __init__(self, api, endpoint='/api/groups/'):
+    def __init__(self, api, endpoint='api/groups/'):
         super(API, self).__init__(api, endpoint=endpoint, cls=Group)
 
     def get(self, group_id=None):

--- a/gophish/api/pages.py
+++ b/gophish/api/pages.py
@@ -3,7 +3,7 @@ from gophish.api import APIEndpoint
 
 
 class API(APIEndpoint):
-    def __init__(self, api, endpoint='/api/pages/'):
+    def __init__(self, api, endpoint='api/pages/'):
         super(API, self).__init__(api, endpoint=endpoint, cls=Page)
 
     def get(self, page_id=None):

--- a/gophish/api/smtp.py
+++ b/gophish/api/smtp.py
@@ -3,7 +3,7 @@ from gophish.api import APIEndpoint
 
 
 class API(APIEndpoint):
-    def __init__(self, api, endpoint='/api/smtp/'):
+    def __init__(self, api, endpoint='api/smtp/'):
         super(API, self).__init__(api, endpoint=endpoint, cls=SMTP)
 
     def get(self, smtp_id=None):

--- a/gophish/api/templates.py
+++ b/gophish/api/templates.py
@@ -3,7 +3,7 @@ from gophish.api import APIEndpoint
 
 
 class API(APIEndpoint):
-    def __init__(self, api, endpoint='/api/templates/'):
+    def __init__(self, api, endpoint='api/templates/'):
         super(API, self).__init__(api, endpoint=endpoint, cls=Template)
 
     def get(self, template_id=None):


### PR DESCRIPTION
 The API client was appending an extra forward slash infront of all
request paths, which caused the CSRF protection to trigger on state
changing request. This commit fixes the issue.

Related issue in Gophish:
https://github.com/gophish/gophish/issues/1506