### PR TITLE
Added validation of "host" attribute

### DIFF
--- a/gophish/client.py
+++ b/gophish/client.py
@@ -10,7 +10,10 @@ class GophishClient(object):
 
     def __init__(self, api_key, host=DEFAULT_URL, **kwargs):
         self.api_key = api_key
-        self.host = host
+        if host.endswith('/'):
+            self.host = host
+        else:
+            self.host = host + '/'
         self._client_kwargs = kwargs
 
     def execute(self, method, path, **kwargs):


### PR DESCRIPTION
Modified the init functionality to add a trailing forward slash to the
host attribute if none is provided, which is required.

This commit complements https://github.com/gophish/api-client-python/pull/18 ,
which caused an issue if a trailing slash was missing.