### PR TITLE
Update certifi, requests and urllib3 dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ setup(
     ],
     install_requires=[
         "appdirs==1.4.4",
-        "certifi==2020.6.20",
+        "certifi==2021.5.30",
         "chardet==3.0.4",
         "idna==2.10",
         "packaging==20.4",
         "pyparsing==2.4.7",
         "python-dateutil==2.8.1",
-        "requests==2.24.0",
+        "requests==2.26.0",
         "six==1.15.0",
-        "urllib3==1.25.10"
+        "urllib3==1.26.7"
     ],
 )


### PR DESCRIPTION
Resolves the following messages by PIP:

```
gophish 0.5.1 requires certifi==2020.6.20, but you have certifi 2021.5.30 which is incompatible.
gophish 0.5.1 requires requests==2.24.0, but you have requests 2.26.0 which is incompatible.
gophish 0.5.1 requires urllib3==1.25.10, but you have urllib3 1.26.7 which is incompatible.
```

Fix #30